### PR TITLE
[rxjs] only import the needed object & operators.

### DIFF
--- a/src/components/info-window.ts
+++ b/src/components/info-window.ts
@@ -9,7 +9,8 @@ import {
 
 import { OptionBuilder } from '../services/option-builder';
 import { Ng2Map } from '../services/ng2-map';
-import { Subject } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/debounceTime';
 
 const INPUTS = `
   content, disableAutoPan, maxWidth, pixelOffset, position, zIndex

--- a/src/components/ng2-map.component.ts
+++ b/src/components/ng2-map.component.ts
@@ -14,7 +14,8 @@ import { OptionBuilder } from '../services/option-builder';
 import { NavigatorGeolocation } from '../services/navigator-geolocation';
 import { GeoCoder } from '../services/geo-coder';
 import { Ng2Map } from '../services/ng2-map';
-import { Subject } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/debounceTime';
 import { IJson } from '../services/util';
 
 const INPUTS = `

--- a/src/directives/marker.ts
+++ b/src/directives/marker.ts
@@ -4,7 +4,7 @@ import { OptionBuilder } from '../services/option-builder';
 import { NavigatorGeolocation } from '../services/navigator-geolocation';
 import { GeoCoder } from '../services/geo-coder';
 import { Ng2Map } from '../services/ng2-map';
-import { Subject } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
 
 const INPUTS = `
   anchorPoint, animation, clickable, cursor, draggable, icon, label, opacity

--- a/src/services/geo-coder.ts
+++ b/src/services/geo-coder.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
 
 /**
  *   Provides [defered/promise API](https://docs.angularjs.org/api/ng/service/$q)

--- a/src/services/navigator-geolocation.ts
+++ b/src/services/navigator-geolocation.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable, Subject } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
+import { Observable } from 'rxjs/Observable';
 import { IJson } from './util';
 
 /**

--- a/src/services/ng2-map.ts
+++ b/src/services/ng2-map.ts
@@ -1,5 +1,5 @@
 import { Injectable, SimpleChange } from '@angular/core';
-import { Subject } from 'rxjs/Rx';
+import { Subject } from 'rxjs/Subject';
 import { OptionBuilder } from './option-builder';
 import { GeoCoder } from './geo-coder';
 import { Ng2MapComponent } from '../components/ng2-map.component';


### PR DESCRIPTION
> To import only what you need by patching (this is useful for size-sensitive bundling)

see https://github.com/ReactiveX/rxjs#installation-and-usage