### PR TITLE
Add INPUT/OUTPUT as properties to Ng2MapComponent

### DIFF
--- a/src/components/ng2-map.component.ts
+++ b/src/components/ng2-map.component.ts
@@ -53,6 +53,62 @@ export class Ng2MapComponent implements OnChanges, OnDestroy, AfterViewInit {
   public map: google.maps.Map;
   public mapOptions: google.maps.MapOptions = {};
 
+  // INPUTS
+  public backgroundColor: any;
+  public center: any;
+  public disableDefaultUI: any;
+  public disableDoubleClickZoom: any;
+  public draggable: any;
+  public draggableCursor: any;
+  public draggingCursor: any;
+  public heading: any;
+  public keyboardShortcuts: any;
+  public mapMaker: any;
+  public mapTypeControl: any;
+  public mapTypeId: any;
+  public maxZoom: any;
+  public minZoom: any;
+  public noClear: any;
+  public overviewMapControl: any;
+  public panControl: any;
+  public panControlOptions: any;
+  public rotateControl: any;
+  public scaleControl: any;
+  public scrollwheel: any;
+  public streetView: any;
+  public styles: any;
+  public tilt: any;
+  public zoom: any;
+  public streetViewControl: any;
+  public zoomControl: any;
+  public mapTypeControlOptions: any;
+  public overviewMapControlOptions: any;
+  public rotateControlOptions: any;
+  public scaleControlOptions: any;
+  public streetViewControlOptions: any;
+  public options: any;
+
+  // OUTPUTS
+  public bounds_changed: any;
+  public center_changed: any;
+  public click: any;
+  public dblclick: any;
+  public drag: any;
+  public dragend: any;
+  public dragstart: any;
+  public heading_changed: any;
+  public idle: any;
+  public typeid_changed: any;
+  public mousemove: any;
+  public mouseout: any;
+  public mouseover: any;
+  public projection_changed: any;
+  public resize: any;
+  public rightclick: any;
+  public tilesloaded: any;
+  public tile_changed: any;
+  public zoom_changed: any;
+
   public inputChanges$ = new Subject();
   public mapReady$: EventEmitter<any> = new EventEmitter();
 


### PR DESCRIPTION
When using Ionic2 RC4 (currently latest version as of Dec 29 2016) the ngc compiler complains about the INPUT / OUTPUT dynamic properties on the Ng2MapComponent class. Adding these as properties fixes the issue.

Wasn't sure if you wanted me to include the compiled files in my PR or not. I can open another PR that has everything generated if you would like.

Error when using latest ionic2 RC4 

```
[15:17:20]  Error at 
            /home/sam/work/nibbler/.tmp/node_modules/ng2-map/dist/components/ng2-map.component.ngfactory.ts:144:20 
[15:17:20]  Property 'backgroundColor' does not exist on type 'Ng2MapComponent'. 
...
[15:17:20]  Error at 
            .tmp/node_modules/ng2-map/dist/components/ng2-map.component.ngfactory.ts:400:20 
[15:17:20]  Property 'options' does not exist on type 'Ng2MapComponent'. 
[15:17:20]  ngc failed 
[15:17:20]  ionic-app-script task: "build" 
```