### PR TITLE
Don't use hat for versioning typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "strip-loader": "^0.1.2",
     "ts-loader": "^1.0.0",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.7",
+    "typescript": "2.0.10",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.16.2",
     "zone.js": "^0.6.21"


### PR DESCRIPTION
Specifying `"typescript": "^2.0.7"` caused npm install to use latest typescript 2.1.x which meant npm build stopped working due to similar issue specified here https://github.com/angular/angular/issues/13305