### PR TITLE
[#30] configure Google API url through Ng2MapeModule

### DIFF
--- a/app/app.component.ts
+++ b/app/app.component.ts
@@ -1,6 +1,4 @@
 import { Component } from '@angular/core';
-//noinspection TypeScriptCheckImport
-import { Ng2MapComponent } from 'ng2-map';
 
 @Component({
   selector: 'my-app',
@@ -9,9 +7,4 @@ import { Ng2MapComponent } from 'ng2-map';
 export class AppComponent {
   public center = 'Brampton, Canada';
   public positions = [ ];
-
-  constructor() {
-    Ng2MapComponent['apiUrl'] = 'https://maps.google.com/maps/api/js?key=AIzaSyCbMGRUwcqKjlYX4h4-P6t-xcDryRYLmCM' +
-      '&libraries=visualization,places,drawing';
-  }
 }

--- a/app/main.ts
+++ b/app/main.ts
@@ -21,7 +21,16 @@ import { AppComponent } from './app.component';
 import { APP_ROUTER_PROVIDERS, APP_ROUTER_COMPONENTS } from './app.route';
 
 @NgModule({
-  imports: [BrowserModule, FormsModule, HttpModule, APP_ROUTER_PROVIDERS, Ng2MapModule, Ng2UtilsModule ],
+  imports: [
+    BrowserModule,
+    FormsModule,
+    HttpModule,
+    APP_ROUTER_PROVIDERS,
+    Ng2MapModule.forRoot({
+      apiUrl: 'https://maps.google.com/maps/api/js?key=AIzaSyCbMGRUwcqKjlYX4h4-P6t-xcDryRYLmCM' +
+      '&libraries=visualization,places,drawing',
+    }),
+    Ng2UtilsModule ],
   declarations: [AppComponent, APP_ROUTER_COMPONENTS],
   providers: [
     { provide: LocationStrategy, useClass: HashLocationStrategy },

--- a/src/components/ng2-map.component.ts
+++ b/src/components/ng2-map.component.ts
@@ -8,6 +8,8 @@ import {
   EventEmitter,
   SimpleChanges,
   AfterViewInit,
+  OpaqueToken,
+  Inject,
  } from '@angular/core';
 
 import { OptionBuilder } from '../services/option-builder';
@@ -17,6 +19,8 @@ import { Ng2Map } from '../services/ng2-map';
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/debounceTime';
 import { IJson, toCamelCase } from '../services/util';
+
+export const NG_MAP_CONFIG_TOKEN = new OpaqueToken('NG_MAP_CONFIG_TOKEN');
 
 const INPUTS = [
   'backgroundColor', 'center', 'disableDefaultUI', 'disableDoubleClickZoom', 'draggable', 'draggableCursor',
@@ -75,7 +79,8 @@ export class Ng2MapComponent implements OnChanges, OnDestroy, AfterViewInit {
     public zone: NgZone,
     public geolocation: NavigatorGeolocation,
     public geoCoder: GeoCoder,
-    public ng2Map: Ng2Map
+    public ng2Map: Ng2Map,
+    @Inject(NG_MAP_CONFIG_TOKEN) private config: { apiUrl: string }
   ) {
     window['ng2MapRef'] = { zone: this.zone, componentFn: () => this.initializeMap(), map: null};
     if (typeof google === 'undefined' || typeof google.maps === 'undefined' || !google.maps.Map) {
@@ -107,8 +112,8 @@ export class Ng2MapComponent implements OnChanges, OnDestroy, AfterViewInit {
       script.id = 'ng2-map-api';
 
       // script.src = "https://maps.google.com/maps/api/js?callback=initNg2Map";
-      let apiUrl = Ng2MapComponent['apiUrl'] || 'https://maps.google.com/maps/api/js';
-      apiUrl += apiUrl.indexOf('?') ? '&' : '?';
+      let apiUrl = this.config.apiUrl || 'https://maps.google.com/maps/api/js';
+      apiUrl += apiUrl.indexOf('?') !== -1 ? '&' : '?';
       script.src = apiUrl + 'callback=initNg2Map';
       document.querySelector('body').appendChild(script);
     }

--- a/src/ng2-map.module.ts
+++ b/src/ng2-map.module.ts
@@ -1,11 +1,11 @@
-import { NgModule } from '@angular/core';
+import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { OptionBuilder } from './services/option-builder';
 import { GeoCoder } from './services/geo-coder';
 import { NavigatorGeolocation } from './services/navigator-geolocation';
 
-import { Ng2MapComponent } from './components/ng2-map.component';
+import { Ng2MapComponent, NG_MAP_CONFIG_TOKEN } from './components/ng2-map.component';
 import { InfoWindow } from './components/info-window';
 import { CustomMarker } from './components/custom-marker';
 
@@ -37,7 +37,19 @@ const COMPONENTS_DIRECTIVES = [
 @NgModule({
   imports: [ CommonModule ],
   declarations: COMPONENTS_DIRECTIVES,
-  providers: [GeoCoder, NavigatorGeolocation, Ng2Map, OptionBuilder],
-  exports: [COMPONENTS_DIRECTIVES]
+  exports: [COMPONENTS_DIRECTIVES],
 })
-export class Ng2MapModule {}
+export class Ng2MapModule {
+  static forRoot(config: { apiUrl?: string } = {}): ModuleWithProviders {
+    return {
+      ngModule: Ng2MapModule,
+      providers: [
+        { provide: NG_MAP_CONFIG_TOKEN, useValue: config },
+        GeoCoder,
+        NavigatorGeolocation,
+        Ng2Map,
+        OptionBuilder,
+      ],
+    };
+  }
+}


### PR DESCRIPTION
Fix #30 
This PR introduce a breaking change:

Before:
```ts
@NgModule({
  imports: [
    ...
    Ng2MapModule
  ]
})
export class AppModule
```

After:
```ts
@NgModule({
  imports: [
    ...
    Ng2MapModule.forRoot()
  ]
})
export class AppModule
```

