### PR TITLE
Concurrency fix during property update ;  events available as outputs

### DIFF
--- a/src/components/ng2-map.component.ts
+++ b/src/components/ng2-map.component.ts
@@ -10,6 +10,7 @@ import {
   AfterViewInit,
   OpaqueToken,
   Inject,
+  Output
  } from '@angular/core';
 
 import { OptionBuilder } from '../services/option-builder';
@@ -37,7 +38,7 @@ const OUTPUTS = [
   'bounds_changed', 'center_changed', 'click', 'dblclick', 'drag', 'dragend', 'dragstart', 'heading_changed', 'idle',
   'typeid_changed', 'mousemove', 'mouseout', 'mouseover', 'projection_changed', 'resize', 'rightclick',
   'tilesloaded', 'tile_changed', 'zoom_changed',
-  //to avoid DOM event conflicts
+  // to avoid DOM event conflicts
   'mapClick', 'mapMouseover', 'mapMouseout', 'mapMousemove', 'mapDrag', 'mapDragend', 'mapDragstart'
 ];
 
@@ -62,7 +63,7 @@ export class Ng2MapComponent implements OnChanges, OnDestroy, AfterViewInit {
   public mapOptions: google.maps.MapOptions = {};
 
   public inputChanges$ = new Subject();
-  public mapReady$: EventEmitter<any> = new EventEmitter();
+  @Output() public mapReady$: EventEmitter<any> = new EventEmitter();
 
   // map objects by group
   public infoWindows: any = {};
@@ -149,7 +150,7 @@ export class Ng2MapComponent implements OnChanges, OnDestroy, AfterViewInit {
       .debounceTime(1000)
       .subscribe((changes: SimpleChanges) => this.ng2Map.updateGoogleObject(this.map, changes));
 
-    //expose map object for test and debugging on window
+    // expose map object for test and debugging on window
     window['ng2MapRef'].map = this.map;
   }
 
@@ -189,7 +190,7 @@ export class Ng2MapComponent implements OnChanges, OnDestroy, AfterViewInit {
     }
   }
 
-  //map.markers, map.circles, map.heatmapLayers.. etc
+  // map.markers, map.circles, map.heatmapLayers.. etc
   addToMapObjectGroup(mapObjectName: string, mapObject: any) {
     let groupName = toCamelCase(mapObjectName.toLowerCase()) + 's'; // e.g. markers
     this.map[groupName] = this.map[groupName] || [];

--- a/src/directives/base-map-directive.ts
+++ b/src/directives/base-map-directive.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, SimpleChanges, OnInit, OnChanges, OnDestroy } from '@angular/core';
+import { EventEmitter, SimpleChanges, OnInit, OnChanges, OnDestroy, Output } from '@angular/core';
 
 import { OptionBuilder } from '../services/option-builder';
 import { Ng2Map } from '../services/ng2-map';
@@ -10,7 +10,7 @@ export abstract class BaseMapDirective implements OnInit, OnChanges, OnDestroy {
 
   public ng2Map: Ng2Map;
   public optionBuilder: OptionBuilder;
-  public initialized$: EventEmitter<any> = new EventEmitter();
+  @Output() public initialized$: EventEmitter<any> = new EventEmitter();
   public libraryName: string;
   protected _subscriptions = [];
 

--- a/src/services/ng2-map.ts
+++ b/src/services/ng2-map.ts
@@ -28,15 +28,17 @@ export class Ng2Map {
   }
 
   updateGoogleObject(object: any, changes: SimpleChanges) {
-    let val: any, currentValue: any, setMethodName: string;
+    let val: any, currentValue: any, setMethodName: string, that = this;
     if (object) {
       for (let key in changes) {
         setMethodName = `set${key.replace(/^[a-z]/, x => x.toUpperCase()) }`;
         currentValue = changes[key].currentValue;
         if (['position', 'center'].indexOf(key) !== -1 && typeof currentValue === 'string') {
-          this.geoCoder.geocode({address: currentValue}).subscribe(results => {
-            object[setMethodName](results[0].geometry.location);
-          });
+          ((setMethodName) => {
+            that.geoCoder.geocode({address: currentValue}).subscribe(results => {
+              object[setMethodName](results[0].geometry.location);
+            });
+          })(setMethodName)
         } else {
           val =  this.optionBuilder.googlize(currentValue);
           object[setMethodName](val);
@@ -46,12 +48,14 @@ export class Ng2Map {
   }
 
   updateProperty(object: any, key: string, currentValue: any): void {
-    let val: any, setMethodName: string;
+    let val: any, setMethodName: string, that = this;
     setMethodName = `set${key.replace(/^[a-z]/, x => x.toUpperCase()) }`;
     if (['position', 'center'].indexOf(key) !== -1 && typeof currentValue === 'string') {
-      this.geoCoder.geocode({address: currentValue}).subscribe(results => {
-        object[setMethodName](results[0].geometry.location);
-      });
+      ((setMethodName) => {
+        that.geoCoder.geocode({address: currentValue}).subscribe(results => {
+          object[setMethodName](results[0].geometry.location);
+        });
+      })(setMethodName)
     } else {
       val =  this.optionBuilder.googlize(currentValue);
       object[setMethodName](val);


### PR DESCRIPTION
Concurrency fix - when several properties change at the same time, the correct value us now updated - not just the last one

... previously, the setMethodName could change before the subscription actually got executed

... also, adds @Output() to initialized$ and mapReady$