### PR TITLE
keep the google map handler for useages outside google map

### DIFF
--- a/src/components/ng2-map.component.ts
+++ b/src/components/ng2-map.component.ts
@@ -114,7 +114,7 @@ export class Ng2MapComponent implements OnChanges, OnDestroy, AfterViewInit {
       window['ng2MapRef'].forEach( ng2MapRef => {
         ng2MapRef.zone.run(function() { ng2MapRef.componentFn(); });
       });
-      window['ng2MapRef'] = [];
+      window['ng2MapRef'].splice(0, window['ng2MapRef'].length);
     };
     if ((!window['google'] || !window['google']['maps']) && !document.querySelector('#ng2-map-api')) {
       let script = document.createElement( 'script' );


### PR DESCRIPTION
Thinking in angular, operating DOM elements and the event handler is not recommended. 
We should keep googlemap handler anywhere so that the user can use it in the component without the $event handler and also for those useages of outside the googlemap, for example, do something with the map by click a button which is not an element of the map.

Now, I just modified the window.ng2MapRef.map to not be cleared after the function named addGoogleMapsApi is called.Maybe we should keep the handler anywhere else for components to use it by injecting it